### PR TITLE
Adaption to zonemaster-backend v4.0.1

### DIFF
--- a/js/api.js
+++ b/js/api.js
@@ -13,68 +13,6 @@ var zonalizer = {
 		main: function () {
 
 			$(document).on({
-				// to get ip address of nameserver if ip-field is empty
-				'blur': function () {
-					var this_fields   = $(this),
-						proxynonce    = $('#proxynonce').text(),
-						nameserver    = this_fields.val(),
-						next_ip_field = $(':input:eq(' + ($(':input').index(this_fields) + 1) + ')'),
-						get_ip        = '/?action=proxy&method=get_ns_ips&params=' + nameserver + '&nonce=' + proxynonce + '&cache=true',
-						debug         = 'no';
-
-						debug = zmDefs.debug;
-
-					if ( nameserver.length > 0 && next_ip_field.val().length === 0 ) {
-
-						$.getJSON(get_ip, function (data) {
-							// if we don't have a nonce problem, continue
-							if ( data != '-1' && data != '' ) {
-								var index,
-								api_ns,
-								len = data.result.length,
-								wrapper = $('.js-input-nameserver-wrap'); // Nameservers field wrapper;
-
-								for ( index = 0; index < len; ++index) {
-								  if ( index in data.result ) {
-									api_ns = data.result[index];
-
-									var ip_address = api_ns[nameserver];
-									if ( index === 0 ) {
-										next_ip_field.val(ip_address);
-									} else {
-										var data = {
-											'action': 'get_nameservers_html',
-											'index': index,
-											'ns': nameserver,
-											'ip': ip_address,
-											'nonce': $('#proxynonce').text()
-										};
-										// Post the AJAX query to Zonemaster class
-										$.post('/', data, function(response) {
-
-											if ( response != '' && response != '-1' ) {
-												var responseData = $.parseJSON(response);
-												$('.ns-error').remove();
-												$(wrapper).append(responseData);
-											} else {
-												$(wrapper).append('<span class="label alert fade-in fast ns-error">' + zmDefs.error_text + '</span>');
-											}
-										});
-									}
-								  }
-								}
-							} else {
-								if(debug === 'yes') { console.log( 'Check ip for nameserver: Nonce is not working or server is offline This is current nonce: ' + $('#proxynonce').text() ); }
-							}
-
-						});
-
-					}
-
-				}
-			}, 'input.js-field-blur');
-
-			$(document).on({
 				// to check that ip-address is correct (lighter check)
 				'blur': function () {
 					var this_field   = $(this),
@@ -394,7 +332,7 @@ var zonalizer = {
 							var temp,
 								starttest = true;
 							//check status
-							var urltocheck = '/?action=proxy&method=test_progress&params=' + id + '&nonce=' + proxynonce;
+							var urltocheck = '/?action=proxy&method=test_progress&test_id=' + id + '&nonce=' + proxynonce;
 							function checkstatus(urltocheck,callback){
 								starttest = false;
 								temp = $.getJSON(urltocheck, function (data) {

--- a/zonemaster/class-zonemaster.php
+++ b/zonemaster/class-zonemaster.php
@@ -752,7 +752,7 @@ class Zonemaster extends ZonemasterSettings {
 		$progress = $this->analyze_zone_tld(
 			[
 				'method' => 'test_progress',
-				'params' => [ 'test_id' => trim( $testid ) ],
+				'params' => [ 'test_id' => esc_attr( $testid ) ],
 			]
 		);
 		return $progress['result'];

--- a/zonemaster/class-zonemaster.php
+++ b/zonemaster/class-zonemaster.php
@@ -57,7 +57,8 @@ class Zonemaster extends ZonemasterSettings {
 		$request_oldtest_inline = isset( $_REQUEST['oldtest_inline'] ) ? $this->regexp_check( $_REQUEST['oldtest_inline'] ) : false;
 		$request_method         = isset( $_REQUEST['method'] ) ? sanitize_text_field( $_REQUEST['method'] ) : '';
 		$request_params         = isset( $_REQUEST['params'] ) ? sanitize_text_field( $_REQUEST['params'] ) : '';
-
+		$request_test_id        = isset( $_REQUEST['test_id'] ) ? sanitize_text_field( $_REQUEST['test_id'] ) : '';
+		
 		// Check that backend is not offline
 		if ( strpos( $version, 'OFFLINE' ) !== false ) {
 			$GLOBALS['OFFLINE'] = $this->offline_text();
@@ -128,16 +129,42 @@ class Zonemaster extends ZonemasterSettings {
 			if ( check_ajax_referer( $version, 'nonce' ) ) {
 				// Allowed backend api call via this function
 				$allow = [
-					'get_ns_ips',
 					'test_progress',
 					'get_data_from_parent_zone',
 				];
 
-				if ( '' === $request_method || '' === $request_params ) {
+				if ( '' === $request_method) {
 					exit;
 				}
 
 				$method = $request_method;
+
+				// if method is 'test_progress' - create a request that matches ZM backend 4.0.1 format
+				if ( $method == 'test_progress' ) {
+					$test_id = $request_test_id;
+					$defaults = [
+						'method' => trim( $method ),
+						'params' => ['test_id' => trim( $test_id ) ],
+					];
+
+					$request_curl = $this->verify_and_curl_request( $defaults );
+
+					if ( $request_curl ) {
+						// Generate appropriate content-type header.
+						$is_xhr = isset( $_SERVER['HTTP_X_REQUESTED_WITH'] ) && strtolower( $_SERVER['HTTP_X_REQUESTED_WITH'] ) == 'xmlhttprequest';
+						header( 'Content-type: application/' . ( $is_xhr ? 'json' : 'x-javascript' ) );
+
+						// Generate JSON string
+						$json = wp_json_encode( $request_curl );
+						print $json;
+					}
+					exit();
+				}
+
+				if ( '' === $request_params ) {
+					exit;
+				}
+
 				$params = $request_params;
 
 				if ( in_array( $method, $allow, true ) ) {
@@ -636,7 +663,7 @@ class Zonemaster extends ZonemasterSettings {
 		$parent_addresses = $this->verify_and_curl_request(
 			[
 				'method'            => 'get_data_from_parent_zone',
-				'params'            => $zone_tld,
+				'params'            => [ 'domain'=> $zone_tld ],
 				'create_transient'  => true,
 				'transient_seconds' => $this->settings( 'transient_parent_zone' ),
 			]
@@ -716,28 +743,6 @@ class Zonemaster extends ZonemasterSettings {
 	}
 
 	/**
-	 * [get_ns_ips description]
-	 *
-	 * @param  [type] $ns [description]
-	 * @return [type]     [description]
-	 */
-	public function get_ns_ips( $ns ) {
-
-		if ( '' !== $ns ) {
-			$addresses = $this->analyze_zone_tld(
-				[
-					'method'            => 'get_ns_ips',
-					'params'            => esc_attr( $ns ),
-					'create_transient'  => true,
-					'transient_seconds' => sanitize_text_field( $this->settings( 'transient_ip_nameserver' ) ),
-				]
-			);
-			return $addresses['result'];
-		}
-		return false;
-	}
-
-	/**
 	 * [test_progress description]
 	 *
 	 * @param  [type] $testid [description]
@@ -747,7 +752,7 @@ class Zonemaster extends ZonemasterSettings {
 		$progress = $this->analyze_zone_tld(
 			[
 				'method' => 'test_progress',
-				'params' => [ 'test_id' => esc_attr( $testid ) ],
+				'params' => [ 'test_id' => trim( $testid ) ],
 			]
 		);
 		return $progress['result'];
@@ -872,8 +877,6 @@ class Zonemaster extends ZonemasterSettings {
 			// Mask for frontend_params (define which keys to include)
 			$frontend_intersect = [
 				'domain'    => '',
-				'client_id' => '',
-				'profile'   => '',
 			];
 			$get_history_params = [
 				'offset'          => 0,

--- a/zonemaster/page-start.php
+++ b/zonemaster/page-start.php
@@ -127,30 +127,13 @@ if ( '' !== $post_zone_tld && ( ( '' !== $post_tld_zonemaster && wp_verify_nonce
 							}
 						}
 
-						// if user requested us to find the IP-address
-						if ( '' === $ip_field || $check_ip_address ) {
-							// Call API and get ip
-							$addresses = $zm->get_ns_ips( $ns_field );
-							// we get both ipv4 & ipv6 if nameserver has both
-							foreach ( $addresses as $address ) {
-								$ip_address = $address[ $ns_field ];
-								// do html for fields
-								$nameservers_html .= $zm->nameservers_html( $key, $ns_field, $ip_address );
-								// prepare array for test engine
-								$nameservers_array[] = [
-									'ns' => $ns_field,
-									'ip' => $ip_address,
-								];
-							}
-						} else {
-							// do html for fields
-							$nameservers_html .= $zm->nameservers_html( $key, $ns_field, $ip_field );
-							// prepare array for test engine
-							$nameservers_array[] = [
-								'ns' => $ns_field,
-								'ip' => $ip_field,
-							];
-						}
+						// do html for fields
+						$nameservers_html .= $zm->nameservers_html( $key, $ns_field, $ip_field );
+						// prepare array for test engine
+						$nameservers_array[] = [
+							'ns' => $ns_field,
+							'ip' => $ip_field,
+						];
 
 						// Correct tab, no-js
 						$pre_delegated_domain_check = true;
@@ -208,9 +191,8 @@ if ( '' !== $post_zone_tld && ( ( '' !== $post_tld_zonemaster && wp_verify_nonce
 				$params = [
 					'client_id'      => 'IIS Zonemaster frontend',
 					'domain'         => $verify_zone_tld,
-					'profile'        => 'default_profile',
+					'profile'        => 'default',
 					'client_version' => '1',
-					'advanced'       => true,
 					'ipv6'           => $check_ip_v6,
 					'ipv4'           => $check_ip_v4,
 					'nameservers'    => $nameservers_array,
@@ -386,19 +368,6 @@ if ( $do_test_progress || '' !== $requested_test_id ) {
 						echo $zm->nameservers_html( '0' );
 					}
 					?>
-				</div>
-
-				<div class="row align-right">
-
-					<div class="columns small-6 text-right show-if-no-js">
-						<button type="submit" name="check_ip_address" class="tiny expanded button success">
-							<?php _e( 'Get IP-address', 'zm_text' ); ?>
-						</button>
-						<small>
-							<?php _e( 'Leave ip-field empty if you want us to fetch the IP-address then you start the test', 'zm_text' ); ?>
-						</small>
-					</div>
-
 				</div>
 
 				<div>


### PR DESCRIPTION
Modified API calls to match new API format (version_info and start_domain_test where modified and get_ns_ips was removed).

Renamed profile_default to default.

Modified the call from javascript for 'test_progress' and renamed 'params' to 'test_id' which then is used in class-zonemaster.php to create a correct call to backend.

Removed all code related to get_ns_ips.